### PR TITLE
Add Anonymous & Email OTP Sign-In + API Prefix Config & Cookie Header Utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ final (user, error) = await BetterAuth.instance.client.signInWithEmailAndPasswor
 final error = await BetterAuth.instance.client.signOut();
 ```
 
+### Anonymous Sign-In
+
+```dart
+// Sign in anonymously
+final (user, error) = await BetterAuth.instance.client.signInAnonymous();
+```
+
 ### OAuth Login
 
 For social authentication, you have two main approaches:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ final error = await BetterAuth.instance.client.signOut();
 final (user, error) = await BetterAuth.instance.client.signInAnonymous();
 ```
 
+### Email OTP Sign-In
+
+```dart
+// Send OTP to email
+final (result, error) = await BetterAuth.instance.client.sendVerificationOtp("user@example.com");
+// Sign in with OTP
+final (user, error) = await BetterAuth.instance.client.signInWithOtp(
+  email: "user@example.com",
+  otp: "123456",
+);
+```
+
 ### OAuth Login
 
 For social authentication, you have two main approaches:

--- a/lib/src/better_auth_flutter_base.dart
+++ b/lib/src/better_auth_flutter_base.dart
@@ -21,10 +21,13 @@ class BetterAuth {
     return _client;
   }
 
-  static Future<void> init({required Uri baseUrl}) async {
+  static Future<void> init({
+    required Uri baseUrl,
+    String apiPrefixPath = "/api/auth",
+  }) async {
     if (_isInitialized) return;
     await KVStore.init();
-    await Api.init();
+    await Api.init(apiPrefixPath: apiPrefixPath);
     Config.initialize(uri: baseUrl);
     _isInitialized = true;
   }

--- a/lib/src/core/api/api.dart
+++ b/lib/src/core/api/api.dart
@@ -11,9 +11,12 @@ import 'dart:developer';
 class Api {
   static final hc = http.Client();
 
+  static late final String apiPrefixPath;
+
   static late PersistCookieJar _cookieJar;
 
-  static Future<void> init() async {
+  static Future<void> init({String apiPrefixPath = "/api/auth"}) async {
+    Api.apiPrefixPath = apiPrefixPath;
     try {
       final cacheDir = await getApplicationCacheDirectory();
       _cookieJar = PersistCookieJar(
@@ -44,7 +47,7 @@ class Api {
     final Uri uri = Uri(
       scheme: Config.scheme,
       host: host,
-      path: "/api/auth$path",
+      path: "$apiPrefixPath$path",
       queryParameters: queryParameters,
       port: Config.port,
     );
@@ -82,7 +85,7 @@ class Api {
             return Cookie.fromSetCookieValue(cookieString.trim());
           }).toList();
 
-      bool isAuthRoute = uri.path.contains("/api/auth");
+      bool isAuthRoute = uri.path.contains(apiPrefixPath);
       if (isAuthRoute) {
         final tempUri = Uri(scheme: uri.scheme, host: uri.host);
         await _cookieJar.saveFromResponse(tempUri, cookiesList);

--- a/lib/src/core/api/api.dart
+++ b/lib/src/core/api/api.dart
@@ -27,6 +27,14 @@ class Api {
     }
   }
 
+  static Future<String?> getCookieHeader({Uri? uri}) async {
+    final cookies = await _cookieJar.loadForRequest(
+      uri ?? Uri(scheme: Config.scheme, host: Config.host),
+    );
+    if (cookies.isEmpty) return null;
+    return cookies.map((c) => "${c.name}=${c.value}").join("; ");
+  }
+
   static Future<(dynamic, BetterAuthFailure?)> sendRequest(
     String path, {
     required MethodType method,
@@ -52,11 +60,11 @@ class Api {
       port: Config.port,
     );
 
-    final cookies = await _cookieJar.loadForRequest(
-      Uri(scheme: uri.scheme, host: uri.host),
+    final cookies = await getCookieHeader(
+      uri: Uri(scheme: uri.scheme, host: uri.host),
     );
-    if (cookies.isNotEmpty) {
-      headers["Cookie"] = cookies.map((c) => "${c.name}=${c.value}").join("; ");
+    if (cookies != null) {
+      headers["Cookie"] = cookies;
     }
 
     final http.Response response;

--- a/lib/src/core/api/data/models/user.dart
+++ b/lib/src/core/api/data/models/user.dart
@@ -5,6 +5,7 @@ class User {
   final String email;
   final String name;
   final String? image;
+  final bool? isAnonymous;
   final bool emailVerified;
   final DateTime createdAt;
   final DateTime updatedAt;
@@ -14,6 +15,7 @@ class User {
     required this.email,
     required this.name,
     this.image,
+    this.isAnonymous,
     required this.emailVerified,
     required this.createdAt,
     required this.updatedAt,
@@ -26,6 +28,7 @@ class User {
       "name": name,
       "image": image,
       "emailVerified": emailVerified,
+      "isAnonymous": isAnonymous,
       "createdAt": createdAt.toIso8601String(),
       "updatedAt": updatedAt.toIso8601String(),
     };
@@ -37,6 +40,8 @@ class User {
       email: map["email"] as String,
       name: map["name"] as String,
       image: map["image"] != null ? map["image"] as String : null,
+      isAnonymous:
+          map["isAnonymous"] != null ? map["isAnonymous"] as bool : null,
       emailVerified: map["emailVerified"] as bool,
       createdAt: DateTime.parse(map["createdAt"] as String),
       updatedAt: DateTime.parse(map["updatedAt"] as String),

--- a/lib/src/core/constants/app_endpoints.dart
+++ b/lib/src/core/constants/app_endpoints.dart
@@ -2,6 +2,7 @@ class AppEndpoints {
   static const String getSession = "/get-session";
   static const String signUpWithEmailAndPassword = "/sign-up/email";
   static const String signInWithEmailAndPassword = "/sign-in/email";
+  static const String signInAnonymous = "/sign-in/anonymous";
   static const String signOut = "/sign-out";
   static const String socialSignIn = "/sign-in/social";
   static const String listAccounts = "/list-accounts";

--- a/lib/src/core/constants/app_endpoints.dart
+++ b/lib/src/core/constants/app_endpoints.dart
@@ -3,10 +3,12 @@ class AppEndpoints {
   static const String signUpWithEmailAndPassword = "/sign-up/email";
   static const String signInWithEmailAndPassword = "/sign-in/email";
   static const String signInAnonymous = "/sign-in/anonymous";
+  static const String signInEmailOtp = "/sign-in/email-otp";
   static const String signOut = "/sign-out";
   static const String socialSignIn = "/sign-in/social";
   static const String listAccounts = "/list-accounts";
   static const String sendVerificationEmail = "/send-verification-email";
+  static const String sendVerificationOtp = "/email-otp/send-verification-otp";
   static const String verifyEmail = "/verify-email";
   static const String deleteUser = "/delete-user";
 }

--- a/lib/src/modules/accounts.dart
+++ b/lib/src/modules/accounts.dart
@@ -1,5 +1,4 @@
 import "package:better_auth_flutter/better_auth_flutter.dart";
-import "package:better_auth_flutter/src/core/api/data/models/account.dart";
 
 class Accounts {
   static Future<(List<Account>?, BetterAuthFailure?)> listAccounts() async {

--- a/lib/src/modules/auth.dart
+++ b/lib/src/modules/auth.dart
@@ -58,6 +58,37 @@ class Auth {
     }
   }
 
+  static Future<(User?, BetterAuthFailure?)> signInEmailOtp({
+    required String email,
+    required String otp,
+  }) async {
+    try {
+      final (result, error) = await Api.sendRequest(
+        AppEndpoints.signInEmailOtp,
+        method: MethodType.post,
+        body: {"email": email, "otp": otp},
+      );
+
+      if (error != null) return (null, error);
+
+      if (result is! Map<String, dynamic>) {
+        return (null, BetterAuthFailure(code: BetterAuthError.unKnownError));
+      }
+
+      final user = User.fromMap(result["user"] as Map<String, dynamic>);
+
+      return (user, null);
+    } catch (e) {
+      return (
+        null,
+        BetterAuthFailure(
+          code: BetterAuthError.unKnownError,
+          message: e.toString(),
+        ),
+      );
+    }
+  }
+
   static Future<(User?, BetterAuthFailure?)> signInWithEmailAndPassword({
     required String email,
     required String password,

--- a/lib/src/modules/auth.dart
+++ b/lib/src/modules/auth.dart
@@ -30,6 +30,34 @@ class Auth {
     }
   }
 
+  static Future<(User?, BetterAuthFailure?)> signInAnonymous() async {
+    try {
+      final (result, error) = await Api.sendRequest(
+        AppEndpoints.signInAnonymous,
+        method: MethodType.post,
+      );
+
+      if (error != null) return (null, error);
+
+      if (result is! Map<String, dynamic>) {
+        return (null, BetterAuthFailure(code: BetterAuthError.unKnownError));
+      }
+
+      final user = User.fromMap(result["user"] as Map<String, dynamic>);
+      await KVStore.set(KVStoreKeys.user, user.toJson());
+
+      return (user, null);
+    } catch (e) {
+      return (
+        null,
+        BetterAuthFailure(
+          code: BetterAuthError.unKnownError,
+          message: e.toString(),
+        ),
+      );
+    }
+  }
+
   static Future<(User?, BetterAuthFailure?)> signInWithEmailAndPassword({
     required String email,
     required String password,

--- a/lib/src/modules/better_auth_client.dart
+++ b/lib/src/modules/better_auth_client.dart
@@ -66,6 +66,12 @@ class BetterAuthClient {
   Future<(User?, BetterAuthFailure?)> Function() signInAnonymous =
       Auth.signInAnonymous;
 
+  Future<(User?, BetterAuthFailure?)> Function({
+    required String email,
+    required String otp,
+  })
+  signInEmailOtp = Auth.signInEmailOtp;
+
   Future<BetterAuthFailure?> Function() signOut = Auth.signOut;
 
   Future<(User?, BetterAuthFailure?)> Function({
@@ -96,6 +102,9 @@ class BetterAuthClient {
 
   Future<BetterAuthFailure?> Function({required String verificationToken})
   verifyEmail = Verification.verifyEmail;
+
+  Future<BetterAuthFailure?> Function({required String email})
+  sendVerificationOtp = Verification.sendVerificationOtp;
 
   Future<(List<Account>?, BetterAuthFailure?)> Function() listAccounts =
       Accounts.listAccounts;

--- a/lib/src/modules/better_auth_client.dart
+++ b/lib/src/modules/better_auth_client.dart
@@ -63,6 +63,9 @@ class BetterAuthClient {
   })
   signInWithEmailAndPassword = Auth.signInWithEmailAndPassword;
 
+  Future<(User?, BetterAuthFailure?)> Function() signInAnonymous =
+      Auth.signInAnonymous;
+
   Future<BetterAuthFailure?> Function() signOut = Auth.signOut;
 
   Future<(User?, BetterAuthFailure?)> Function({

--- a/lib/src/modules/verification.dart
+++ b/lib/src/modules/verification.dart
@@ -60,4 +60,31 @@ class Verification {
       );
     }
   }
+
+  static Future<BetterAuthFailure?> sendVerificationOtp({
+    required String email,
+  }) async {
+    try {
+      final (result, error) = await Api.sendRequest(
+        AppEndpoints.sendVerificationOtp,
+        method: MethodType.post,
+        body: {"email": email, "type": "sign-in"},
+      );
+
+      if (error != null) return error;
+
+      final status = result["success"] as bool;
+
+      if (!status) {
+        return BetterAuthFailure(code: BetterAuthError.unKnownError);
+      }
+
+      return null;
+    } catch (e) {
+      return BetterAuthFailure(
+        code: BetterAuthError.unKnownError,
+        message: e.toString(),
+      );
+    }
+  }
 }


### PR DESCRIPTION
First of all, thank you for this package! 🙌  
I'm currently using it in my **production app**, and I had the need to implement a few additional features which, in my opinion, extend and improve the current API surface.
I really appreciate the work you've done, and I hope this contribution will be helpful to others using the package as well.

## ✨ Features Added

- **Anonymous Sign-In**  
  Enables users to sign in without providing credentials.

- **Email OTP Sign-In**  
  Implements support for one-time password (OTP) login via email.

- **`apiPrefixPath` in `init` Method**  
  Adds a new `apiPrefixPath` parameter to the initialization method to allow custom API endpoint prefixes (e.g., `/api/v1/auth`), useful for versioning or proxy setups.

- **Static `getCookieHeader()` Method**  
  Introduces and exposes a static `getCookieHeader()` function for use in external authenticated requests, improving integration flexibility.

Thanks again for maintaining this package. Looking forward to your feedback!